### PR TITLE
Migrate React.PropTypes to prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-combo-keys",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "React component to bind keyboard shortcuts",
   "main": "./lib/index.js",
   "scripts": {
@@ -35,6 +35,7 @@
     "react": "^15.4.2"
   },
   "dependencies": {
-    "mousetrap": "^1.6.0"
+    "mousetrap": "^1.6.0",
+    "prop-types": "^15.5.10"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Mousetrap from 'mousetrap';
 
@@ -95,11 +96,11 @@ class ComboKeys extends React.Component {
 }
 
 ComboKeys.propTypes = {
-    children: React.PropTypes.node,
-    keyMap: React.PropTypes.objectOf(
-        React.PropTypes.func
+    children: PropTypes.node,
+    keyMap: PropTypes.objectOf(
+        PropTypes.func
     ).isRequired,
-    stopAt: React.PropTypes.func
+    stopAt: PropTypes.func
 };
 
 /*
@@ -119,10 +120,10 @@ class ComboKey extends React.PureComponent {
 }
 
 ComboKey.propTypes = {
-    children: React.PropTypes.node,
-    combo: React.PropTypes.string.isRequired,
-    onTrigger: React.PropTypes.func.isRequired,
-    stopAt: React.PropTypes.func
+    children: PropTypes.node,
+    combo: PropTypes.string.isRequired,
+    onTrigger: PropTypes.func.isRequired,
+    stopAt: PropTypes.func
 };
 
 export {


### PR DESCRIPTION
Cleared deprecation warnings by migrating from React.PropTypes to the external prop-types package.